### PR TITLE
fix(backend): use app name, descr. and slogan from .env

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -1,4 +1,6 @@
-APP_NAME=Laravel
+APP_NAME=OpenQDA
+APP_DESCRIPTION="A Sustainable Free/Libre Open Source Research Infrastructure"
+APP_SLOGAN="Collaborative Qualitative Research"
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true

--- a/web/config/app.php
+++ b/web/config/app.php
@@ -17,6 +17,8 @@ return [
     */
 
     'name' => env('APP_NAME', 'Laravel'),
+    'description' => env('APP_DESCRIPTION', null),
+    'slogan' => env('APP_SLOGAN', null),
     'admins' => explode(',', env('ADMINS', null)),
     'logo' => 'logos/logo_512x512_96dpi.PNG',
     'background' => 'logos/openQDA_Background_diverser.PNG',

--- a/web/resources/js/Pages/LandingPage.vue
+++ b/web/resources/js/Pages/LandingPage.vue
@@ -9,6 +9,8 @@
 import { Head, router } from '@inertiajs/vue3';
 import Footer from '../Layouts/Footer.vue';
 
+
+console.debug(import.meta.env)
 defineProps({
   background: String,
   canLogin: Boolean,
@@ -44,15 +46,15 @@ function onLogout() {
                 <div
                   class="relative px-3 py-1 text-sm leading-6 text-gray-500 rounded-full ring-1 ring-gray-900/10 hover:ring-gray-900/20"
                 >
-                  A Sustainable Free/Libre Open Source Research Software
+                  {{$page.props.description}}
                 </div>
                 <h1
                   class="text-4xl font-bold tracking-tight sm:text-6xl text-cerulean-700"
                 >
-                  OpenQDA
+                  {{$page.props.title}}
                 </h1>
                 <p class="mt-6 text-lg leading-8 text-black">
-                  Collaborative Qualitative Research
+                  {{$page.props.slogan}}
                 </p>
                 <img
                   :src="$page.props.logo"

--- a/web/resources/js/Pages/LandingPage.vue
+++ b/web/resources/js/Pages/LandingPage.vue
@@ -9,8 +9,7 @@
 import { Head, router } from '@inertiajs/vue3';
 import Footer from '../Layouts/Footer.vue';
 
-
-console.debug(import.meta.env)
+console.debug(import.meta.env);
 defineProps({
   background: String,
   canLogin: Boolean,
@@ -46,15 +45,15 @@ function onLogout() {
                 <div
                   class="relative px-3 py-1 text-sm leading-6 text-gray-500 rounded-full ring-1 ring-gray-900/10 hover:ring-gray-900/20"
                 >
-                  {{$page.props.description}}
+                  {{ $page.props.description }}
                 </div>
                 <h1
                   class="text-4xl font-bold tracking-tight sm:text-6xl text-cerulean-700"
                 >
-                  {{$page.props.title}}
+                  {{ $page.props.title }}
                 </h1>
                 <p class="mt-6 text-lg leading-8 text-black">
-                  {{$page.props.slogan}}
+                  {{ $page.props.slogan }}
                 </p>
                 <img
                   :src="$page.props.logo"

--- a/web/resources/js/Pages/LandingPage.vue
+++ b/web/resources/js/Pages/LandingPage.vue
@@ -9,7 +9,6 @@
 import { Head, router } from '@inertiajs/vue3';
 import Footer from '../Layouts/Footer.vue';
 
-console.debug(import.meta.env);
 defineProps({
   background: String,
   canLogin: Boolean,

--- a/web/routes/web.php
+++ b/web/routes/web.php
@@ -25,9 +25,12 @@ use Inertia\Inertia;
 
 Route::get('/', function () {
     return Inertia::render('LandingPage', [
+        'title' => config('app.name'),
         'background' => asset(config('app.background')),
+        'slogan' => config('app.slogan'),
         'canLogin' => Route::has('login'),
         'canRegister' => Route::has('register'),
+        'description' => config('app.description'),
         'bgtl' => config('app.bgtl'),
         'bgtr' => config('app.bgtr'),
         'bgbr' => config('app.bgbr'),


### PR DESCRIPTION
This makes the app title, description and slogan configurable via .env

Note: This is just quick fix and does not remove all hard-coded entries from the backend, yet, which we should do asap in a future PR.
