### PR TITLE
feature(routes): add link to license in footer

### DIFF
--- a/web/resources/js/Layouts/Footer.vue
+++ b/web/resources/js/Layouts/Footer.vue
@@ -42,6 +42,7 @@ const navigation = {
   main: [
     { name: 'Imprint', href: '/imprint' },
     { name: 'FAQ', href: '/faq' },
+    { name: 'License', href: '/license' },
     //{ name: 'Documentation', href: 'https://openqda.github.io/user-docs/', external: true },
     { name: 'GitHub', href: 'https://github.com/openqda', external: true },
   ],

--- a/web/resources/markdown/license.md
+++ b/web/resources/markdown/license.md
@@ -1,0 +1,13 @@
+OpenQDA is a sustainable, free/libre Open Source Software for collaborative qualitative research. Copyright (C) 2024 ZeMKI, Universität Bremen
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see https://www.gnu.org/licenses/.
+
+The core software of this project is released under the APGL-3.0 license, which you can read in [our license file](https://github.com/openqda/openqda/blob/main/LICENSE).
+
+Plugins (which includes services) may be distributed under a different license. Please see their own license files in their respective directories
+
+For more information, please go to https://github.com/openqda/openqda

--- a/web/routes/web.php
+++ b/web/routes/web.php
@@ -63,6 +63,20 @@ Route::get('/imprint', function () {
     ]);
 })->name('imprint');
 
+Route::get('/license', function () {
+    return Inertia::render('RenderHtml', [
+        'background' => asset(config('app.background')),
+        'html' => Str::of(file_get_contents(resource_path('markdown/license.md')))->markdown(),
+        'canLogin' => Route::has('login'),
+        'canRegister' => Route::has('register'),
+        'bgtl' => config('app.bgtl'),
+        'bgtr' => config('app.bgtr'),
+        'bgbr' => config('app.bgbr'),
+        'bgbl' => config('app.bgbl'),
+
+    ]);
+})->name('license');
+
 Route::middleware([
     'auth:sanctum',
     config('jetstream.auth_session'),


### PR DESCRIPTION
This puts a new link "license" into the footer, which routes to a page, that displays our license (markdown file) as rendered html.


