### PR TITLE
fix(client): enable csv export button on Analysis page, once at least…

### DIFF
--- a/web/resources/js/Pages/AnalysisPage.vue
+++ b/web/resources/js/Pages/AnalysisPage.vue
@@ -26,7 +26,7 @@
               color="cerulean"
               :disabled="!hasSelections"
               :icon="ArrowDownTrayIcon"
-              :label="hasSelections"
+              :label="'CSV'"
             />
           </span>
         </Headline2>

--- a/web/resources/js/Pages/AnalysisPage.vue
+++ b/web/resources/js/Pages/AnalysisPage.vue
@@ -26,7 +26,7 @@
               color="cerulean"
               :disabled="!hasSelections"
               :icon="ArrowDownTrayIcon"
-              label="CSV"
+              :label="hasSelections"
             />
           </span>
         </Headline2>
@@ -332,7 +332,7 @@ const updateHasSelection = debounce(() => {
       });
     };
 
-    iterateCodes(allCodes);
+    iterateCodes(allCodes.value);
 
     if (entry.codes.length > 0) {
       values.push(entry);


### PR DESCRIPTION
Fix for #31 

Note., that users have to select at least one file/code combination that results in a selection in ortder to enable the csv button