### PR TITLE
Bugfix: utf-8 compatibility for txt files

### DIFF
--- a/.github/workflows/backend_lint.yml
+++ b/.github/workflows/backend_lint.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.3 ]
+        php: [8.3]
 
     steps:
       - name: Checkout code
@@ -25,11 +25,12 @@ jobs:
           extensions: json, dom, curl, libxml, mbstring
           coverage: none
 
-      - name: go into the backend folder
-        run: cd web
-
-      - name: Install Pint
-        run: composer global require laravel/pint
+      - name: Install dependencies
+        run: |
+          cd web
+          composer install
 
       - name: Run Pint
-        run: pint --test
+        run: |
+          cd web
+          ./vendor/bin/pint --test

--- a/web/app/Http/Controllers/SourceController.php
+++ b/web/app/Http/Controllers/SourceController.php
@@ -402,6 +402,7 @@ class SourceController extends Controller
             File::makeDirectory($outputDirectory, 0755, true);
         }
         $outputHtmlPath = $outputDirectory.'/'.pathinfo($txtFilePath, PATHINFO_FILENAME).'.html';
+
         // Read the contents of the TXT file
         $txtContent = file_get_contents($txtFilePath);
 
@@ -410,11 +411,23 @@ class SourceController extends Controller
             return 'Error reading file.';
         }
 
+        // Detect the encoding of the text
+        $encoding = mb_detect_encoding($txtContent, mb_list_encodings(), true);
+        if ($encoding === false) {
+            // Handle error if encoding could not be detected
+            return 'Error detecting encoding.';
+        }
+
+        // Convert the content to UTF-8 encoding
+        $utf8Content = mb_convert_encoding($txtContent, 'UTF-8', $encoding);
+
         // Convert special characters to HTML entities to prevent HTML injection
-        $htmlContent = htmlspecialchars($txtContent);
+        $htmlContent = htmlspecialchars($utf8Content);
 
         // Convert line breaks to <br> tags
         $htmlContent = nl2br($htmlContent);
+
+        // Save the HTML content to the output file
         file_put_contents($outputHtmlPath, $htmlContent);
 
         return $htmlContent;

--- a/web/app/Http/Controllers/SourceController.php
+++ b/web/app/Http/Controllers/SourceController.php
@@ -421,7 +421,7 @@ class SourceController extends Controller
         // Convert the content to UTF-8 encoding
         $utf8Content = mb_convert_encoding($txtContent, 'UTF-8', $encoding);
 
-        // Convert special characters to HTML entities to prevent HTML injection
+        // Convert special characters to HTML entities to p1revent HTML injection
         $htmlContent = htmlspecialchars($utf8Content);
 
         // Convert line breaks to <br> tags


### PR DESCRIPTION
With this we enable the conversion from different encodings to utf-8 to correctly show characters in our preparation and coding editor.
Attached you can find a danish encoded text in ISO-8859-1 (also known as Latin-1) and a chinese text encoded in Chinese GB2312.

I have no idea what those texts says 😄 

Fix #49 

[cinese text.txt](https://github.com/user-attachments/files/15910303/cinese.text.txt)
[latin-1-encoding.txt](https://github.com/user-attachments/files/15910304/latin-1-encoding.txt)
