### PR TITLE
Bugfix: send navigation updates only when in a team

### DIFF
--- a/web/resources/js/Layouts/AppLayout.vue
+++ b/web/resources/js/Layouts/AppLayout.vue
@@ -71,7 +71,8 @@ function cleanup() {
 }
 
 onMounted(() => {
-  if (getSharedTeam()) {
+  const sharedTeam = getSharedTeam();
+  if (sharedTeam && Object.keys(sharedTeam).length > 0) {
     userInAteam = true;
     setPresence();
     document.addEventListener('beforeunload', cleanup);


### PR DESCRIPTION
The check if the user was in a team or not was bugged, now we're sending navigation updates only when a user is in a team.
To verify it, check [https://stagingqda.uni-bremen.de/](https://stagingqda.uni-bremen.de/) in a non-shared project, you should not see the "navigation" endpoint being called every 5 seconds.

Check also offline, in another branch, you should see the call happening, along with some weird errors.