### PR TITLE
fix(ui): make files list scrollable on overflow

### DIFF
--- a/web/resources/js/Pages/PreparationPage.vue
+++ b/web/resources/js/Pages/PreparationPage.vue
@@ -4,7 +4,7 @@
     <div class="flex w-screen h-screen">
       <!-- Left Side -->
       <div
-        class="pt-2 text-ellipsis overflow-hidden"
+        class="pt-2 text-ellipsis overflow-auto"
         ref="leftSide"
         :style="{ width: leftWidth + 'px' }"
         v-show="editorSourceRef.selected === false || focus === false"


### PR DESCRIPTION
This makes the FIles list in the preparation menu scrollable, if files exceed the vertical size of the container.