### PR TITLE
Cleanup dead references

### DIFF
--- a/web/resources/js/Pages/CodingPage.vue
+++ b/web/resources/js/Pages/CodingPage.vue
@@ -42,9 +42,7 @@
             @change="(value) => (codesView = value)"
           />
         </div>
-        <Cleanup
-            v-if="codesView === 'cleanup'"
-        />
+        <Cleanup v-if="codesView === 'cleanup'" />
         <CodeTree
           v-for="codebook in codebooks"
           :key="codebook.id"
@@ -100,9 +98,9 @@ import { asyncTimeout } from '../utils/asyncTimeout.js';
 import ActivityIndicator from '../Components/ActivityIndicator.vue';
 import { useCreateDialog } from '../dialogs/useCreateDialog.js';
 import { attemptAsync } from '../Components/notification/attemptAsync.js';
-import { useCleanup } from './coding/cleanup/useCleanup.js'
-import Cleanup from './coding/cleanup/Cleanup.vue'
-import { flashMessage } from '../Components/notification/flashMessage.js'
+import { useCleanup } from './coding/cleanup/useCleanup.js';
+import Cleanup from './coding/cleanup/Cleanup.vue';
+import { flashMessage } from '../Components/notification/flashMessage.js';
 
 const props = defineProps(['source', 'sources', 'allCodes', 'projectId']);
 //------------------------------------------------------------------------
@@ -222,8 +220,10 @@ onMounted(async () => {
 
   const result = await attemptAsync(() => initCoding());
   if (result?.clean?.length) {
-    result.clean.forEach(entry => CleanupCtx.add(entry));
-    flashMessage('Unresolved references found. Please run cleanup.', { type: 'error' })
+    result.clean.forEach((entry) => CleanupCtx.add(entry));
+    flashMessage('Unresolved references found. Please run cleanup.', {
+      type: 'error',
+    });
   }
 
   codingInitialized.value = true;

--- a/web/resources/js/Pages/coding/cleanup/Cleanup.vue
+++ b/web/resources/js/Pages/coding/cleanup/Cleanup.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { useCleanup } from "./useCleanup";
+import {ref, onMounted} from "vue";
+import CleanupList from "./CleanupList.vue";
+
+const Cleanup = useCleanup();
+const selections = ref([])
+const codes = ref([])
+const codebooks = ref([])
+
+onMounted(() => {
+    const found = Object.values(Cleanup.entries.value)
+    selections.value.push(...found.filter(entry => entry.type === 'selection'));
+    codes.value.push(...found.filter(entry => entry.type === 'code'));
+    codebooks.value.push(...found.filter(entry => entry.type === 'codebook'));
+})
+</script>
+
+<template>
+<CleanupList v-if="selections?.length" title="Selections to clean" :entries="selections" />
+<CleanupList v-if="codes?.length" title="Codes to clean" :entries="codes" />
+<CleanupList v-if="codebooks?.length" title="Codebooks to clean" :entries="codebook" />
+</template>
+
+<style scoped>
+
+</style>

--- a/web/resources/js/Pages/coding/cleanup/Cleanup.vue
+++ b/web/resources/js/Pages/coding/cleanup/Cleanup.vue
@@ -1,27 +1,33 @@
 <script setup lang="ts">
-import { useCleanup } from "./useCleanup";
-import {ref, onMounted} from "vue";
-import CleanupList from "./CleanupList.vue";
+import { useCleanup } from './useCleanup';
+import { ref, onMounted } from 'vue';
+import CleanupList from './CleanupList.vue';
 
 const Cleanup = useCleanup();
-const selections = ref([])
-const codes = ref([])
-const codebooks = ref([])
+const selections = ref([]);
+const codes = ref([]);
+const codebooks = ref([]);
 
 onMounted(() => {
-    const found = Object.values(Cleanup.entries.value)
-    selections.value.push(...found.filter(entry => entry.type === 'selection'));
-    codes.value.push(...found.filter(entry => entry.type === 'code'));
-    codebooks.value.push(...found.filter(entry => entry.type === 'codebook'));
-})
+  const found = Object.values(Cleanup.entries.value);
+  selections.value.push(...found.filter((entry) => entry.type === 'selection'));
+  codes.value.push(...found.filter((entry) => entry.type === 'code'));
+  codebooks.value.push(...found.filter((entry) => entry.type === 'codebook'));
+});
 </script>
 
 <template>
-<CleanupList v-if="selections?.length" title="Selections to clean" :entries="selections" />
-<CleanupList v-if="codes?.length" title="Codes to clean" :entries="codes" />
-<CleanupList v-if="codebooks?.length" title="Codebooks to clean" :entries="codebook" />
+  <CleanupList
+    v-if="selections?.length"
+    title="Selections to clean"
+    :entries="selections"
+  />
+  <CleanupList v-if="codes?.length" title="Codes to clean" :entries="codes" />
+  <CleanupList
+    v-if="codebooks?.length"
+    title="Codebooks to clean"
+    :entries="codebook"
+  />
 </template>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/web/resources/js/Pages/coding/cleanup/CleanupList.vue
+++ b/web/resources/js/Pages/coding/cleanup/CleanupList.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import Button from "../../../Components/interactive/Button.vue";
+import Headline3 from "../../../Components/layout/Headline3.vue";
+import {TrashIcon} from "@heroicons/vue/24/solid";
+
+const props = defineProps({
+    entries: Array,
+    title: String
+})
+const variants = {
+    undefined: 'default',
+    delete: 'destructive',
+    create: 'confirmative'
+}
+</script>
+
+<template>
+    <div class="overflow-x-auto">
+        <Headline3 class="mb-4">{{props.title}}</Headline3>
+        <table class="table-auto border-collapse min-w-full">
+            <thead>
+            <tr>
+                <th class="text-left">Name</th>
+                <th class="text-left">Reason</th>
+                <th class="text-left">Reference</th>
+                <th class="text-right">Actions</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr v-for="entry in props.entries" :key="entry.id">
+                <td>{{entry.name}}</td>
+                <td>{{entry.reason}}</td>
+                <td>{{entry.ref}}</td>
+                <td class="text-right">
+                    <Button v-for="(action, i) in entry.actions"
+                            :key="i"
+                            size="sm"
+                            :variant="variants[action.type]"
+                            @click="action.fn"
+                            :title="action.name">
+                        <TrashIcon class="w-4 h-4" />
+                    </Button>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</template>
+
+<style scoped>
+
+</style>

--- a/web/resources/js/Pages/coding/cleanup/CleanupList.vue
+++ b/web/resources/js/Pages/coding/cleanup/CleanupList.vue
@@ -1,52 +1,52 @@
 <script setup lang="ts">
-import Button from "../../../Components/interactive/Button.vue";
-import Headline3 from "../../../Components/layout/Headline3.vue";
-import {TrashIcon} from "@heroicons/vue/24/solid";
+import Button from '../../../Components/interactive/Button.vue';
+import Headline3 from '../../../Components/layout/Headline3.vue';
+import { TrashIcon } from '@heroicons/vue/24/solid';
 
 const props = defineProps({
-    entries: Array,
-    title: String
-})
+  entries: Array,
+  title: String,
+});
 const variants = {
-    undefined: 'default',
-    delete: 'destructive',
-    create: 'confirmative'
-}
+  undefined: 'default',
+  delete: 'destructive',
+  create: 'confirmative',
+};
 </script>
 
 <template>
-    <div class="overflow-x-auto">
-        <Headline3 class="mb-4">{{props.title}}</Headline3>
-        <table class="table-auto border-collapse min-w-full">
-            <thead>
-            <tr>
-                <th class="text-left">Name</th>
-                <th class="text-left">Reason</th>
-                <th class="text-left">Reference</th>
-                <th class="text-right">Actions</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr v-for="entry in props.entries" :key="entry.id">
-                <td>{{entry.name}}</td>
-                <td>{{entry.reason}}</td>
-                <td>{{entry.ref}}</td>
-                <td class="text-right">
-                    <Button v-for="(action, i) in entry.actions"
-                            :key="i"
-                            size="sm"
-                            :variant="variants[action.type]"
-                            @click="action.fn"
-                            :title="action.name">
-                        <TrashIcon class="w-4 h-4" />
-                    </Button>
-                </td>
-            </tr>
-            </tbody>
-        </table>
-    </div>
+  <div class="overflow-x-auto">
+    <Headline3 class="mb-4">{{ props.title }}</Headline3>
+    <table class="table-auto border-collapse min-w-full">
+      <thead>
+        <tr>
+          <th class="text-left">Name</th>
+          <th class="text-left">Reason</th>
+          <th class="text-left">Reference</th>
+          <th class="text-right">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="entry in props.entries" :key="entry.id">
+          <td>{{ entry.name }}</td>
+          <td>{{ entry.reason }}</td>
+          <td>{{ entry.ref }}</td>
+          <td class="text-right">
+            <Button
+              v-for="(action, i) in entry.actions"
+              :key="i"
+              size="sm"
+              :variant="variants[action.type]"
+              @click="action.fn"
+              :title="action.name"
+            >
+              <TrashIcon class="w-4 h-4" />
+            </Button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </template>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/web/resources/js/Pages/coding/cleanup/useCleanup.js
+++ b/web/resources/js/Pages/coding/cleanup/useCleanup.js
@@ -1,0 +1,19 @@
+import { reactive, toRef } from 'vue'
+
+const state = reactive({})
+
+export const useCleanup = () => {
+    const entries = toRef(state);
+
+    const add = entry => {
+        state[entry.id] = entry
+    }
+
+    const remove = id => {
+        delete state[id];
+    }
+
+    return {
+        add, remove, entries
+    }
+}

--- a/web/resources/js/Pages/coding/cleanup/useCleanup.js
+++ b/web/resources/js/Pages/coding/cleanup/useCleanup.js
@@ -1,19 +1,21 @@
-import { reactive, toRef } from 'vue'
+import { reactive, toRef } from 'vue';
 
-const state = reactive({})
+const state = reactive({});
 
 export const useCleanup = () => {
-    const entries = toRef(state);
+  const entries = toRef(state);
 
-    const add = entry => {
-        state[entry.id] = entry
-    }
+  const add = (entry) => {
+    state[entry.id] = entry;
+  };
 
-    const remove = id => {
-        delete state[id];
-    }
+  const remove = (id) => {
+    delete state[id];
+  };
 
-    return {
-        add, remove, entries
-    }
-}
+  return {
+    add,
+    remove,
+    entries,
+  };
+};

--- a/web/resources/js/Pages/coding/selections/Selections.js
+++ b/web/resources/js/Pages/coding/selections/Selections.js
@@ -68,8 +68,8 @@ class SelectionsStore extends AbstractStore {
   }
 
   init(selections, getCode) {
-    const selectionsToClean = []
-    const selectionsToAdd = []
+    const selectionsToClean = [];
+    const selectionsToAdd = [];
 
     if (this.size.value === 0 && selections.length !== 0) {
       selections.forEach((selection) => {
@@ -77,38 +77,41 @@ class SelectionsStore extends AbstractStore {
         const start = Number(selection.start_position);
         const end = Number(selection.end_position);
         if (code) {
-            selection.start = start;
-            selection.end = end;
-            selection.length = selection.end - selection.start;
-            selection.code = code;
-            selectionsToAdd.push(selection)
+          selection.start = start;
+          selection.end = end;
+          selection.length = selection.end - selection.start;
+          selection.code = code;
+          selectionsToAdd.push(selection);
         } else {
-            selectionsToClean.push({
-                id: selection.id,
-                name: `${start}:${end}`,
-                ref: selection.code_id,
-                type: 'selection',
-                reason: 'Linked code not found.',
-                actions: [{
-                  name: 'Delete Selection',
-                  type: 'delete',
-                  fn: () => Selections.delete({
-                      projectId: selection.project_id,
-                      sourceId: selection.source_id,
-                      selection,
-                      code: { id: null }
-                  })
-                }]
-            })
+          selectionsToClean.push({
+            id: selection.id,
+            name: `${start}:${end}`,
+            ref: selection.code_id,
+            type: 'selection',
+            reason: 'Linked code not found.',
+            actions: [
+              {
+                name: 'Delete Selection',
+                type: 'delete',
+                fn: () =>
+                  Selections.delete({
+                    projectId: selection.project_id,
+                    sourceId: selection.source_id,
+                    selection,
+                    code: { id: null },
+                  }),
+              },
+            ],
+          });
         }
       });
       this.add(...selectionsToAdd);
     }
 
     return {
-        added: selectionsToAdd,
-        clean: selectionsToClean
-    }
+      added: selectionsToAdd,
+      clean: selectionsToClean,
+    };
   }
 }
 

--- a/web/resources/js/Pages/coding/selections/Selections.js
+++ b/web/resources/js/Pages/coding/selections/Selections.js
@@ -68,15 +68,46 @@ class SelectionsStore extends AbstractStore {
   }
 
   init(selections, getCode) {
+    const selectionsToClean = []
+    const selectionsToAdd = []
+
     if (this.size.value === 0 && selections.length !== 0) {
       selections.forEach((selection) => {
         const code = getCode(selection.code_id);
-        selection.start = Number(selection.start_position);
-        selection.end = Number(selection.end_position);
-        selection.length = selection.end - selection.start;
-        selection.code = code;
+        const start = Number(selection.start_position);
+        const end = Number(selection.end_position);
+        if (code) {
+            selection.start = start;
+            selection.end = end;
+            selection.length = selection.end - selection.start;
+            selection.code = code;
+            selectionsToAdd.push(selection)
+        } else {
+            selectionsToClean.push({
+                id: selection.id,
+                name: `${start}:${end}`,
+                ref: selection.code_id,
+                type: 'selection',
+                reason: 'Linked code not found.',
+                actions: [{
+                  name: 'Delete Selection',
+                  type: 'delete',
+                  fn: () => Selections.delete({
+                      projectId: selection.project_id,
+                      sourceId: selection.source_id,
+                      selection,
+                      code: { id: null }
+                  })
+                }]
+            })
+        }
       });
-      this.add(...selections);
+      this.add(...selectionsToAdd);
+    }
+
+    return {
+        added: selectionsToAdd,
+        clean: selectionsToClean
     }
   }
 }
@@ -162,7 +193,7 @@ Selections.delete = async ({ projectId, sourceId, code, selection }) => {
   if (!error && response.status < 400) {
     Selections.by(`${projectId}-${sourceId}`).remove(selectionId);
     const index = code.text.findIndex((i) => i.id === selectionId);
-    code.text.splice(index, 1);
+    if (index > -1) code.text.splice(index, 1);
   }
   // else flash message?
 

--- a/web/resources/js/Pages/coding/selections/useSelections.js
+++ b/web/resources/js/Pages/coding/selections/useSelections.js
@@ -64,7 +64,8 @@ export const useSelections = () => {
   };
   const deleteSelection = async (selection) => {
     const sourceId = source.id;
-    const code = selection.code;
+    const code = selection.code ?? { id: null, texts: [] };
+
     const { response, error } = await Selections.delete({
       projectId,
       selection,

--- a/web/resources/js/domain/codebooks/Codebooks.js
+++ b/web/resources/js/domain/codebooks/Codebooks.js
@@ -23,6 +23,8 @@ class CodebookStore extends AbstractStore {
       });
       this.add(...docs);
     }
+
+    return { added: docs, clean: [] }
   }
 }
 

--- a/web/resources/js/domain/codebooks/Codebooks.js
+++ b/web/resources/js/domain/codebooks/Codebooks.js
@@ -24,7 +24,7 @@ class CodebookStore extends AbstractStore {
       this.add(...docs);
     }
 
-    return { added: docs, clean: [] }
+    return { added: docs, clean: [] };
   }
 }
 

--- a/web/resources/js/domain/codes/Codes.js
+++ b/web/resources/js/domain/codes/Codes.js
@@ -33,24 +33,41 @@ class CodeStore extends AbstractStore {
   }
 
   init(docs) {
+    const codeList = [];
+    const toClean = []
     if (this.size.value === 0 && docs.length > 0) {
-      const codeList = [];
       const parseCodes = (codes, parent = null) => {
         codes.forEach((code) => {
-          code.active = true;
-          code.parent = parent;
-          code.order = getOrder(code.codebook);
-          code.order = getOrder(code.codebook);
+          if (typeof code.codebook === 'undefined' || code.codebook === null) {
+              toClean.push({
+                  id: code.id,
+                  name: code.name,
+                  ref: code.codebook,
+                  type: 'code',
+                  reason: 'Linked codebook not found.',
+                  actions: [{
+                      name: 'Delete Code',
+                      type: 'delete',
+                      fn: () => alert('not implemented :-(')
+                  }]
+              })
+          } else {
+              code.active = true;
+              code.parent = parent;
+              code.order = getOrder(code.codebook);
+              code.order = getOrder(code.codebook);
 
-          codeList.push(code);
-          if (code.children?.length) {
-            parseCodes(code.children, code);
+              codeList.push(code);
+              if (code.children?.length) {
+                  parseCodes(code.children, code);
+              }
           }
         });
       };
       parseCodes(docs);
       this.add(...codeList);
     }
+    return { added: codeList, clean: toClean }
   }
 }
 

--- a/web/resources/js/domain/codes/Codes.js
+++ b/web/resources/js/domain/codes/Codes.js
@@ -34,40 +34,42 @@ class CodeStore extends AbstractStore {
 
   init(docs) {
     const codeList = [];
-    const toClean = []
+    const toClean = [];
     if (this.size.value === 0 && docs.length > 0) {
       const parseCodes = (codes, parent = null) => {
         codes.forEach((code) => {
           if (typeof code.codebook === 'undefined' || code.codebook === null) {
-              toClean.push({
-                  id: code.id,
-                  name: code.name,
-                  ref: code.codebook,
-                  type: 'code',
-                  reason: 'Linked codebook not found.',
-                  actions: [{
-                      name: 'Delete Code',
-                      type: 'delete',
-                      fn: () => alert('not implemented :-(')
-                  }]
-              })
+            toClean.push({
+              id: code.id,
+              name: code.name,
+              ref: code.codebook,
+              type: 'code',
+              reason: 'Linked codebook not found.',
+              actions: [
+                {
+                  name: 'Delete Code',
+                  type: 'delete',
+                  fn: () => alert('not implemented :-('),
+                },
+              ],
+            });
           } else {
-              code.active = true;
-              code.parent = parent;
-              code.order = getOrder(code.codebook);
-              code.order = getOrder(code.codebook);
+            code.active = true;
+            code.parent = parent;
+            code.order = getOrder(code.codebook);
+            code.order = getOrder(code.codebook);
 
-              codeList.push(code);
-              if (code.children?.length) {
-                  parseCodes(code.children, code);
-              }
+            codeList.push(code);
+            if (code.children?.length) {
+              parseCodes(code.children, code);
+            }
           }
         });
       };
       parseCodes(docs);
       this.add(...codeList);
     }
-    return { added: codeList, clean: toClean }
+    return { added: codeList, clean: toClean };
   }
 }
 

--- a/web/resources/js/domain/codes/useCodes.js
+++ b/web/resources/js/domain/codes/useCodes.js
@@ -14,10 +14,23 @@ export const useCodes = () => {
   const codeStore = Codes.by(key);
   const codebookStore = Codebooks.by(projectId);
   const selectionStore = Selections.by(key);
+
   const initCoding = async () => {
-    codebookStore.init(codebooks);
-    codeStore.init(allCodes);
-    selectionStore.init(source.selections, (id) => codeStore.entry(id));
+    const results = { added: [], clean: [] }
+    const toResults = res => {
+        results.added.push(...res.added)
+        results.clean.push(...res.clean)
+    }
+    toResults(codebookStore.init(codebooks));
+    toResults(codeStore.init(allCodes));
+    toResults(selectionStore.init(source.selections, (id) => {
+        try {
+            return codeStore.entry(id)
+        } catch (e) {
+            console.error(e);
+        }
+    }));
+    return results;
   };
 
   //---------------------------------------------------------------------------

--- a/web/resources/js/domain/codes/useCodes.js
+++ b/web/resources/js/domain/codes/useCodes.js
@@ -16,20 +16,22 @@ export const useCodes = () => {
   const selectionStore = Selections.by(key);
 
   const initCoding = async () => {
-    const results = { added: [], clean: [] }
-    const toResults = res => {
-        results.added.push(...res.added)
-        results.clean.push(...res.clean)
-    }
+    const results = { added: [], clean: [] };
+    const toResults = (res) => {
+      results.added.push(...res.added);
+      results.clean.push(...res.clean);
+    };
     toResults(codebookStore.init(codebooks));
     toResults(codeStore.init(allCodes));
-    toResults(selectionStore.init(source.selections, (id) => {
+    toResults(
+      selectionStore.init(source.selections, (id) => {
         try {
-            return codeStore.entry(id)
+          return codeStore.entry(id);
         } catch (e) {
-            console.error(e);
+          console.error(e);
         }
-    }));
+      })
+    );
     return results;
   };
 


### PR DESCRIPTION
We got reports that some "dead" references distract the coding process.

In order to "clean" them, we now have a detection for dead refs on Page Load (Coding Page) and display an extra "cleanup" Tab, where users are able to either delete the related target (selection, code, codebook) or create a new Database entry for the missing reference (code, codebook).


