### PR TITLE
Editor line numbers do recompute on window resize

### DIFF
--- a/web/app/Http/Controllers/SelectionController.php
+++ b/web/app/Http/Controllers/SelectionController.php
@@ -15,9 +15,7 @@ use Illuminate\Support\Facades\Auth;
 
 class SelectionController extends Controller
 {
-    public function index()
-    {
-    }
+    public function index() {}
 
     /**
      * Store a newly created selection.

--- a/web/app/Policies/CodebookPolicy.php
+++ b/web/app/Policies/CodebookPolicy.php
@@ -19,9 +19,7 @@ class CodebookPolicy extends BasePolicy
     /**
      * Determine whether the user can view the model.
      */
-    public function view(User $user, Codebook $codebook): bool
-    {
-    }
+    public function view(User $user, Codebook $codebook): bool {}
 
     /**
      * Determine whether the user can create models.

--- a/web/resources/js/editor/LineNumber.js
+++ b/web/resources/js/editor/LineNumber.js
@@ -15,7 +15,7 @@ export class LineNumber extends Module {
     this.container = document.querySelector(options.container);
     this.listeners = {
       resize: debounce(
-        this.update.bind(this, 'resize'),
+        this._update.bind(this, 'resize'),
         options.resize?.debounce ?? 100
       ),
       textChange: debounce(
@@ -35,7 +35,10 @@ export class LineNumber extends Module {
    */
   update(type, delta /*, old, source */) {
     if (!delta?.ops) return false;
+    return this._update();
+  }
 
+  _update() {
     // Clear old nodes - this is very performance demanding
     // which is why text changes should be done in bulk
     // or debounced when done programmatically

--- a/web/resources/js/editor/PreparationsEditor.vue
+++ b/web/resources/js/editor/PreparationsEditor.vue
@@ -85,8 +85,8 @@ onMounted(() => {
       },
       lineNumber: {
         container: '#lineNumber',
-        textChange: { debounce: 300 },
-        resize: { debounce: 100 },
+        textChange: { debounce: 500 },
+        resize: { debounce: 250 },
       },
       selectionHash: {
         container: '#selection-hash',


### PR DESCRIPTION
Attempted fix for #97 which also uses an increased debounce interval for more fluent text editing