### PR TITLE
Fix: preserve whitespace and fonts across editors

### DIFF
--- a/web/resources/js/Pages/PreparationPage.vue
+++ b/web/resources/js/Pages/PreparationPage.vue
@@ -109,7 +109,7 @@
 </template>
 
 <script setup>
-import { defineProps, onMounted, provide, ref, unref, watch } from 'vue';
+import { defineProps, onMounted, provide, ref, watch } from 'vue';
 import PreparationsEditor from '../editor/PreparationsEditor.vue';
 import FilesManager from '../Components/files/FilesManager.vue';
 import Button from '../Components/interactive/Button.vue';
@@ -199,7 +199,6 @@ function loadFileIntoEditor(source) {
   if (!source?.content) {
     return;
   }
-
   editorSourceRef.value.content = source.content;
   editorSourceRef.value.selected = true;
   editorSourceRef.value.id = source.id;
@@ -230,14 +229,14 @@ function onDocumentDeleted(deletedDocumentId) {
 const saving = ref(false);
 const saved = ref(false);
 
-async function saveQuillContent() {
+async function saveQuillContent(html) {
   saving.value = true;
   const { response, error } = await request({
     url: '/source/update',
     type: 'post',
     body: {
       id: editorSourceRef.value.id,
-      content: unref(editorComponent.value),
+      content: { editorContent: html },
     },
   });
 

--- a/web/resources/js/editor/EditorConfig.js
+++ b/web/resources/js/editor/EditorConfig.js
@@ -14,11 +14,11 @@ Size.whitelist = ['extra-small', 'small', 'medium', 'large'];
 Quill.register(Size, true);
 
 // Add fonts to whitelist and register them
-const FontAttributor = Quill.import('formats/font');
+const FontAttributor = Quill.import('attributors/class/font');
 FontAttributor.whitelist = [
   'arial',
-  'comic-sans',
-  'courier-new',
+  'comic',
+  'courier',
   'georgia',
   'helvetica',
   'lucida',

--- a/web/resources/js/editor/EditorToolbar.vue
+++ b/web/resources/js/editor/EditorToolbar.vue
@@ -5,8 +5,8 @@
     <span class="ql-formats">
       <select class="ql-font" title="Font family">
         <option value="arial" selected>Arial</option>
-        <option value="comic-sans">Comic Sans</option>
-        <option value="courier-new">Courier New</option>
+        <option value="comic">Comic Sans</option>
+        <option value="courier">Courier New</option>
         <option value="georgia">Georgia</option>
         <option value="helvetica">Helvetica</option>
         <option value="lucida">Lucida</option>

--- a/web/resources/js/editor/editor.css
+++ b/web/resources/js/editor/editor.css
@@ -1320,9 +1320,14 @@
   font-family: 'Helvetica Neue', 'Helvetica', 'Open Sans', 'Arial', sans-serif;
 }
 
-.ql-font-courier-new {
+.ql-font-comic {
+  font-family: 'Comic Sans MS', 'Comic Sans', 'Comic Neue', cursive;
+}
+
+.ql-font-courier {
   font-family: 'Courier New', Courier, monospace;
 }
-.ql-font-lucidia {
-  font-family: 'Lucida Sans Unicode', 'Lucida Grande', sans-serif;
+.ql-font-lucida {
+  font-family: 'Lucida Sans Unicode', 'Lucida Grande', 'Apple Chancery',
+    'Lucida Calligraphy', cursive;
 }

--- a/web/resources/js/utils/createHash.js
+++ b/web/resources/js/utils/createHash.js
@@ -1,0 +1,36 @@
+/**
+ *
+ * @param data {any}
+ * @param alg {string=}
+ * @param format {string=}
+ * @return {Promise<string|null>}
+ */
+export const createHash = (data, { alg = 'SHA-256', format = 'hex' } = {}) => {
+  if (!('crypto' in window)) {
+    return Promise.resolve(null);
+  }
+
+  try {
+    return hash({ data, alg, format });
+  } catch {
+    return null;
+  }
+};
+
+const hash = async ({ data, alg, format }) => {
+  const str = JSON.stringify(data, null, 0);
+  const encoder = new TextEncoder();
+  const encoded = encoder.encode(str);
+  const hash = await window.crypto.subtle.digest({ name: alg }, encoded);
+  const buffer = new Uint8Array(hash);
+  switch (format) {
+    case 'hex':
+      return Array.from(buffer)
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+    case 'base64':
+      return window.btoa(String.fromCharCode.apply(String, buffer));
+    default:
+      return String.fromCharCode.apply(String, buffer);
+  }
+};


### PR DESCRIPTION
This fix attempts to address #110 by ensuring to save semantic HTML from editor which contains explicit whitespace characters. Furthermore, fonts are now saved, due to a workaround, as Quill does not correctly register fonts, comprising of multiple words (such as "courier-new").

Finally, editors now generate a hash-sum to allow users inspect content integrity (there are more use cases to it but thats beyond scope of this fix), which also showed a mismatch between preparations-editor and coding-editor, which is also now fixed by using the exact same formatting modules for quill on both.
Note, the integrity of the source is not affected by selections during coding:

**Preparations Editor**

![image](https://github.com/user-attachments/assets/f1886236-768b-4477-bd73-0b6c0df6b1a3)


**Coding Editor**

![image](https://github.com/user-attachments/assets/55c18f93-8dd6-4ecb-91ee-7f62f6746df3)


Edit: please no hate against comic sans! :clown_face: 
