### PR TITLE
fix(ui/deps): move tailwind from postcss to vite config

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
         "@headlessui/vue": "^1.7.23",
         "@heroicons/vue": "^2.2.0",
         "@openqda/visualization": "file:plugins/visualization",
+        "@tailwindcss/vite": "^4.0.13",
         "@thin-storage/core": "^1.0.2",
         "@vitejs/plugin-basic-ssl": "^1.2.0",
         "@vueuse/core": "^12.0.0",
@@ -553,7 +554,6 @@
       "version": "4.0.13",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.0.13.tgz",
       "integrity": "sha512-P9TmtE9Vew0vv5FwyD4bsg/dHHsIsAuUXkenuGUc5gm8fYgaxpdoxIKngCyEMEQxyCKR8PQY5V5VrrKNOx7exg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "enhanced-resolve": "^5.18.1",
@@ -565,7 +565,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -575,7 +574,6 @@
       "version": "4.0.13",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.0.13.tgz",
       "integrity": "sha512-pTH3Ex5zAWC9LbS+WsYAFmkXQW3NRjmvxkKJY3NP1x0KHBWjz0Q2uGtdGMJzsa0EwoZ7wq9RTbMH1UNPceCpWw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -601,7 +599,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -618,7 +615,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -635,7 +631,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -652,7 +647,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -669,7 +663,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -686,7 +679,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -703,7 +695,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -720,7 +711,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -737,7 +727,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -754,7 +743,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -771,7 +759,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -820,6 +807,21 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.0.13.tgz",
+      "integrity": "sha512-0XTd/NoVUAktIDaA4MdXhve0QWYh7WlZg20EHCuBFR80F8FhbVkRX+AY5cjbUP/IO2itHzt0iHc0iSE5kBUMhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.0.13",
+        "@tailwindcss/oxide": "4.0.13",
+        "lightningcss": "1.29.2",
+        "tailwindcss": "4.0.13"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6"
       }
     },
     "node_modules/@tanstack/virtual-core": {
@@ -2062,7 +2064,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
       "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -2148,7 +2149,6 @@
       "version": "5.18.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
       "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -2741,7 +2741,6 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/happy-dom": {
@@ -3413,7 +3412,6 @@
       "version": "1.29.2",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.29.2.tgz",
       "integrity": "sha512-6b6gd/RUXKaw5keVdSEtqFVdzWnU5jMxTUjA2bVcMNPLwSQ08Sv/UodBVtETLCn7k4S1Ibxwh7k68IwLZPgKaA==",
-      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -4638,7 +4636,6 @@
       "version": "4.0.13",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.13.tgz",
       "integrity": "sha512-gbvFrB0fOsTv/OugXWi2PtflJ4S6/ctu6Mmn3bCftmLY/6xRsQVEJPgIIpABwpZ52DpONkCA3bEj5b54MHxF2Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
@@ -4653,7 +4650,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/web/package.json
+++ b/web/package.json
@@ -48,6 +48,7 @@
     "@headlessui/vue": "^1.7.23",
     "@heroicons/vue": "^2.2.0",
     "@openqda/visualization": "file:plugins/visualization",
+    "@tailwindcss/vite": "^4.0.13",
     "@thin-storage/core": "^1.0.2",
     "@vitejs/plugin-basic-ssl": "^1.2.0",
     "@vueuse/core": "^12.0.0",

--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -1,5 +1,0 @@
-export default {
-    plugins: {
-        '@tailwindcss/postcss': {},
-    },
-};

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -2,9 +2,11 @@
 import {defineConfig} from "vite";
 import laravel, {refreshPaths} from "laravel-vite-plugin";
 import vue from "@vitejs/plugin-vue";
+import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
     plugins: [
+        tailwindcss(),
         laravel({
             input: "resources/js/app.js",
             refresh: [


### PR DESCRIPTION
While #114 worked fine, we had issues in updating our staging environment. This PR fixes common build issues by moving away from postcss to the tailwind vite plugin.