### PR TITLE
fix(ui): wrap unsuccessful responses as error responses

### DIFF
--- a/web/resources/js/utils/http/BackendRequest.js
+++ b/web/resources/js/utils/http/BackendRequest.js
@@ -61,6 +61,16 @@ class BackendRequest {
       this.response = error.response ?? null;
       this.error = error;
     }
+
+    if (
+      !this.error &&
+      this.response &&
+      this.response.success === false &&
+      this.response.message
+    ) {
+      this.error = new Error(this.response.message);
+    }
+
     return this;
   }
 }


### PR DESCRIPTION
This PR handles server responses with the pattern `success => false, message => string` and treats them as errors (in order to inform the user via flashmessage)