### PR TITLE
adjust expected performance for intersection calcuations

### DIFF
--- a/web/resources/js/domain/selections/Intersection.test.js
+++ b/web/resources/js/domain/selections/Intersection.test.js
@@ -151,7 +151,7 @@ describe('Intersection', () => {
       Intersections.from(selections);
       end = performance.now();
       const measure2 = end - start;
-      expect(measure2 < 10).toBe(true);
+      expect(measure2 < 50).toBe(true);
 
       // 10000 entries
       selections = inflate(10000, 100);
@@ -159,7 +159,7 @@ describe('Intersection', () => {
       Intersections.from(selections);
       end = performance.now();
       const measure3 = end - start;
-      expect(measure3 < 100).toBe(true);
+      expect(measure3 < 1000).toBe(true);
     });
   });
 });


### PR DESCRIPTION
The client tests CI often fails due to very restrictive expected performance of intersection computation.
This PR increases the expected amount of time to yet agreeable values, respecting the fact that this fn currently scales exponentially.