### PR TITLE
Add SSL certificate troubleshooting guide

### DIFF
--- a/docs/deployment/deployment.md
+++ b/docs/deployment/deployment.md
@@ -19,3 +19,9 @@ Until then, we would like to point you to the following resources:
 
 Manual installation has great overlap with [the manual development installation](../installation/manual.md).
 We will soon provide this guid to cover topics, specific to the production installation (webserver, certificates etc.).
+
+### SSL Certificate Configuration
+
+For SSL certificate setup with the WebSocket server, refer to:
+- [SSL Certificate Troubleshooting Guide](../troubleshooting/ssl-certificates.md) - Essential reading if your WebSocket server has certificate issues
+- [Manual Installation - Real-Time Configuration](../installation/manual.md#real-time-configuration) - Initial SSL setup instructions

--- a/docs/installation/manual.md
+++ b/docs/installation/manual.md
@@ -63,6 +63,8 @@ LARAVEL_WEBSOCKETS_SSL_LOCAL_PK=
 LARAVEL_WEBSOCKETS_SSL_CAFILE=
 ```
 
+**Important:** The WebSocket server requires the **fullchain certificate** (server + intermediate certificates), not just the server certificate. If you encounter SSL issues where your web server works but WebSockets fail, see the [SSL Certificate Troubleshooting Guide](../troubleshooting/ssl-certificates.md).
+
 
 ## Mail logging
 

--- a/docs/troubleshooting/ssl-certificates.md
+++ b/docs/troubleshooting/ssl-certificates.md
@@ -1,0 +1,65 @@
+# SSL Certificate Issues with WebSocket Server
+
+## WebSocket Server Won't Accept Certificate (But Web Server Does)
+
+### The Problem
+
+Your web server (Apache/Nginx) works fine with your SSL certificate, but the WebSocket server throws certificate errors and won't establish secure connections.
+
+### Why This Happens
+
+The WebSocket server uses GuzzleHttp, which relies on PHP cURL for SSL verification. Unlike typical web servers, cURL needs the **complete certificate chain** - not just your server certificate.
+
+Most certificate providers only give you the server certificate (`server.cer`). This works for web servers but fails for GuzzleHttp's SSL verification. You also need the intermediate certificate to build the full chain.
+
+### The Fix
+
+**1. Create the fullchain certificate:**
+
+```bash
+cat server.cer intermediate.cer > fullchain.cer
+```
+
+Order matters: server certificate first, then intermediate.
+
+**2. Update your `.env` file:**
+
+```dotenv
+LARAVEL_WEBSOCKETS_SSL_LOCAL_CERT="/absolute/path/to/fullchain.cer"
+LARAVEL_WEBSOCKETS_SSL_LOCAL_PK="/absolute/path/to/certificate.key.pem"
+LARAVEL_WEBSOCKETS_SSL_CAFILE="/absolute/path/to/fullchain.cer"
+```
+
+Use absolute paths, not relative ones.
+
+**3. Clear Laravel's cache:**
+
+```bash
+php artisan optimize:clear
+```
+
+**4. Restart the WebSocket service:**
+
+```bash
+sudo supervisorctl restart websockets
+```
+
+Or if running manually:
+```bash
+php artisan reverb:start
+```
+
+### Verification
+
+Check your error logs - they should be clean now. Test your real-time features to confirm WebSocket connections work.
+
+## Additional Notes
+
+- Let's Encrypt provides fullchain certificates automatically, so you won't hit this issue with them
+- File permissions matter: 644 for certificates, 600 for private keys
+- Always use absolute paths in `.env` for certificate files
+
+## Related Documentation
+
+- [Manual Installation - SSL Configuration](../installation/manual.md#real-time-configuration)
+- [Deployment Guide](../deployment/deployment.md)


### PR DESCRIPTION
Introduces a new troubleshooting guide for SSL certificate issues with the WebSocket server. Updates deployment and manual installation docs to reference the guide and clarify the need for a fullchain certificate for WebSocket SSL configuration.
