### PR TITLE
ci: optimize client audits

### DIFF
--- a/.github/workflows/client_tests.yml
+++ b/.github/workflows/client_tests.yml
@@ -27,7 +27,6 @@ jobs:
   # checked locally by developers.
   audit:
     name: Client audit
-    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - name: checkout


### PR DESCRIPTION
This adds `continue-on-error: true` for npm client audits and makes the audit to throw a non-zero exit code only when there is a high or critical-level vuln. found.