### PR TITLE
feat: add notes CSV export (#336) [Claude]

### DIFF
--- a/web/resources/js/Pages/AnalysisPage.vue
+++ b/web/resources/js/Pages/AnalysisPage.vue
@@ -40,16 +40,14 @@
               @click="
                 exportNotesToCSV({
                   notes,
-                  codes: codes,
-                  sources: sources,
+                  codes,
+                  sources,
                   users: allUsers,
                 })
               "
               :disabled="!notes.length"
               :title="
-                notes.length
-                  ? 'Export Notes to CSV'
-                  : 'No notes to export'
+                notes.length ? 'Export Notes to CSV' : 'No notes to export'
               "
             >
               Export Notes

--- a/web/resources/js/Pages/AnalysisPage.vue
+++ b/web/resources/js/Pages/AnalysisPage.vue
@@ -12,23 +12,49 @@
 
         <div
           v-if="menuView === 'export'"
-          class="p-3 rounded-md border border-border flex items-center"
+          class="p-3 rounded-md border border-border flex flex-col gap-3"
         >
-          <p class="text-sm text-foreground/60 me-3">
-            You can export your data to a table in csv format. Note, that data
-            is filtered, based on selected sources and codes.
-          </p>
-          <Button
-            @click="exportToCSV({ contents: selection, users: allUsers })"
-            :disabled="!hasSelections"
-            :title="
-              hasSelections
-                ? 'Export to CSV'
-                : 'Select at least one File and Code to export'
-            "
-          >
-            Export to CSV
-          </Button>
+          <div class="flex items-center">
+            <p class="text-sm text-foreground/60 me-3">
+              You can export your data to a table in csv format. Note, that data
+              is filtered, based on selected sources and codes.
+            </p>
+            <Button
+              @click="exportToCSV({ contents: selection, users: allUsers })"
+              :disabled="!hasSelections"
+              :title="
+                hasSelections
+                  ? 'Export to CSV'
+                  : 'Select at least one File and Code to export'
+              "
+            >
+              Export to CSV
+            </Button>
+          </div>
+          <div class="flex items-center">
+            <p class="text-sm text-foreground/60 me-3">
+              Export all notes from this project as a CSV file, including what
+              each note is attached to and who wrote it.
+            </p>
+            <Button
+              @click="
+                exportNotesToCSV({
+                  notes,
+                  codes: codes,
+                  sources: sources,
+                  users: allUsers,
+                })
+              "
+              :disabled="!notes.length"
+              :title="
+                notes.length
+                  ? 'Export Notes to CSV'
+                  : 'No notes to export'
+              "
+            >
+              Export Notes
+            </Button>
+          </div>
         </div>
 
         <div v-show="menuView === 'sources'" class="">
@@ -244,6 +270,7 @@ const pageTitle = ref(`Analysis - ${trunc(props.project.name, 50)}`);
 // SOURCES AND CODES
 //------------------------------------------------------------------------
 const {
+  notes,
   codes,
   checkedCodes,
   allCodesChecked,
@@ -328,7 +355,7 @@ const onVisualizationSelectChange = async (event) => {
 //------------------------------------------------------------------------
 // EXPORTS
 //------------------------------------------------------------------------
-const { exportToCSV } = useExport();
+const { exportToCSV, exportNotesToCSV } = useExport();
 
 onMounted(async () => {
   if (checkedSources.value.size === 0) checkSource('all');

--- a/web/resources/js/exchange/buildNotesCSV.js
+++ b/web/resources/js/exchange/buildNotesCSV.js
@@ -1,0 +1,63 @@
+import { createCSVBuilder } from '../utils/files/createCSVBuilder.js';
+import { toLocaleDateString } from '../utils/date/toLocaleDateString.js';
+
+/**
+ * Builds a CSV string from a project's notes.
+ * Resolves the human-readable name of whatever each note is attached to
+ * (a code, source, or the project itself) by cross-referencing the provided
+ * codes and sources lists.
+ *
+ * @param {object} options
+ * @param {object[]} options.notes - array of note objects
+ * @param {object[]} [options.codes=[]] - array of code objects with id and name
+ * @param {object[]} [options.sources=[]] - array of source objects with id and name
+ * @param {object} options.project - project object with name
+ * @param {object} [options.users={}] - map of userId -> user object
+ * @return {string} CSV string
+ */
+export const buildNotesCSV = ({
+  notes,
+  codes = [],
+  sources = [],
+  project,
+  users = {},
+}) => {
+  const codeMap = Object.fromEntries(codes.map((c) => [c.id, c.name]));
+  const sourceMap = Object.fromEntries(sources.map((s) => [s.id, s.name]));
+
+  const csv = createCSVBuilder({
+    header: [
+      'note',
+      'attached to',
+      'name',
+      'created by',
+      'created at',
+      'visibility',
+    ],
+  });
+
+  notes.forEach((note) => {
+    let targetName = '';
+    if (note.scope === 'code') {
+      targetName = codeMap[note.target] ?? note.target ?? '';
+    } else if (note.scope === 'source') {
+      targetName = sourceMap[note.target] ?? note.target ?? '';
+    } else if (note.scope === 'project') {
+      targetName = project?.name ?? '';
+    } else {
+      targetName = note.target ?? '';
+    }
+
+    const user = note.user ?? users[note.creating_user_id];
+    csv.addRow([
+      note.content ?? '',
+      note.scope ?? '',
+      targetName,
+      user?.name ?? '',
+      toLocaleDateString(note.created_at),
+      note.visibility === 1 ? 'team' : 'private',
+    ]);
+  });
+
+  return csv.build();
+};

--- a/web/resources/js/exchange/buildNotesCSV.js
+++ b/web/resources/js/exchange/buildNotesCSV.js
@@ -38,11 +38,11 @@ export const buildNotesCSV = ({
 
   notes.forEach((note) => {
     let targetName = '';
-    if (note.scope === 'code') {
+    if (note.type === 'code') {
       targetName = codeMap[note.target] ?? note.target ?? '';
-    } else if (note.scope === 'source') {
+    } else if (note.type === 'source') {
       targetName = sourceMap[note.target] ?? note.target ?? '';
-    } else if (note.scope === 'project') {
+    } else if (note.type === 'project') {
       targetName = project?.name ?? '';
     } else {
       targetName = note.target ?? '';
@@ -51,7 +51,7 @@ export const buildNotesCSV = ({
     const user = note.user ?? users[note.creating_user_id];
     csv.addRow([
       note.content ?? '',
-      note.scope ?? '',
+      note.type ?? '',
       targetName,
       user?.name ?? '',
       toLocaleDateString(note.created_at),

--- a/web/resources/js/exchange/buildNotesCSV.test.js
+++ b/web/resources/js/exchange/buildNotesCSV.test.js
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'vitest';
+import { buildNotesCSV } from './buildNotesCSV.js';
+
+const project = { name: 'Test Project' };
+
+describe('buildNotesCSV', () => {
+  test('produces only a header row when there are no notes', () => {
+    const result = buildNotesCSV({ notes: [], project });
+    expect(result).toBe('note;attached to;name;created by;created at;visibility\n');
+  });
+
+  test('resolves the name of the code a note is attached to', () => {
+    const notes = [
+      {
+        content: 'Interesting quote',
+        scope: 'code',
+        target: 'code-1',
+        creating_user_id: 'user-1',
+        user: { name: 'Alice' },
+        created_at: null,
+        visibility: 0,
+      },
+    ];
+    const codes = [{ id: 'code-1', name: 'Drinking' }];
+    const result = buildNotesCSV({ notes, codes, project });
+    expect(result).toContain('Drinking');
+    expect(result).toContain('Interesting quote');
+  });
+
+  test('resolves the name of the source a note is attached to', () => {
+    const notes = [
+      {
+        content: 'About this file',
+        scope: 'source',
+        target: 'src-1',
+        creating_user_id: 'user-1',
+        user: { name: 'Bob' },
+        created_at: null,
+        visibility: 1,
+      },
+    ];
+    const sources = [{ id: 'src-1', name: 'breakfast_recording.txt' }];
+    const result = buildNotesCSV({ notes, sources, project });
+    expect(result).toContain('breakfast_recording.txt');
+  });
+
+  test('uses the project name for project-scoped notes', () => {
+    const notes = [
+      {
+        content: 'Overall thought',
+        scope: 'project',
+        target: 'proj-1',
+        creating_user_id: 'user-1',
+        user: { name: 'Carol' },
+        created_at: null,
+        visibility: 0,
+      },
+    ];
+    const result = buildNotesCSV({ notes, project });
+    expect(result).toContain('Test Project');
+  });
+
+  test('marks private notes as "private" and team notes as "team"', () => {
+    const notes = [
+      {
+        content: 'Private note',
+        scope: 'project',
+        target: 'proj-1',
+        user: { name: 'Alice' },
+        created_at: null,
+        visibility: 0,
+      },
+      {
+        content: 'Team note',
+        scope: 'project',
+        target: 'proj-1',
+        user: { name: 'Alice' },
+        created_at: null,
+        visibility: 1,
+      },
+    ];
+    const result = buildNotesCSV({ notes, project });
+    expect(result).toContain('private');
+    expect(result).toContain('team');
+  });
+
+  test('falls back to users map when note has no embedded user object', () => {
+    const notes = [
+      {
+        content: 'A note',
+        scope: 'project',
+        target: 'proj-1',
+        creating_user_id: 'user-42',
+        created_at: null,
+        visibility: 0,
+      },
+    ];
+    const users = { 'user-42': { name: 'Dave' } };
+    const result = buildNotesCSV({ notes, project, users });
+    expect(result).toContain('Dave');
+  });
+});

--- a/web/resources/js/exchange/buildNotesCSV.test.js
+++ b/web/resources/js/exchange/buildNotesCSV.test.js
@@ -6,14 +6,16 @@ const project = { name: 'Test Project' };
 describe('buildNotesCSV', () => {
   test('produces only a header row when there are no notes', () => {
     const result = buildNotesCSV({ notes: [], project });
-    expect(result).toBe('note;attached to;name;created by;created at;visibility\n');
+    expect(result).toBe(
+      'note;attached to;name;created by;created at;visibility\n'
+    );
   });
 
   test('resolves the name of the code a note is attached to', () => {
     const notes = [
       {
         content: 'Interesting quote',
-        scope: 'code',
+        type: 'code',
         target: 'code-1',
         creating_user_id: 'user-1',
         user: { name: 'Alice' },
@@ -31,7 +33,7 @@ describe('buildNotesCSV', () => {
     const notes = [
       {
         content: 'About this file',
-        scope: 'source',
+        type: 'source',
         target: 'src-1',
         creating_user_id: 'user-1',
         user: { name: 'Bob' },
@@ -48,7 +50,7 @@ describe('buildNotesCSV', () => {
     const notes = [
       {
         content: 'Overall thought',
-        scope: 'project',
+        type: 'project',
         target: 'proj-1',
         creating_user_id: 'user-1',
         user: { name: 'Carol' },
@@ -64,7 +66,7 @@ describe('buildNotesCSV', () => {
     const notes = [
       {
         content: 'Private note',
-        scope: 'project',
+        type: 'project',
         target: 'proj-1',
         user: { name: 'Alice' },
         created_at: null,
@@ -72,7 +74,7 @@ describe('buildNotesCSV', () => {
       },
       {
         content: 'Team note',
-        scope: 'project',
+        type: 'project',
         target: 'proj-1',
         user: { name: 'Alice' },
         created_at: null,
@@ -88,7 +90,7 @@ describe('buildNotesCSV', () => {
     const notes = [
       {
         content: 'A note',
-        scope: 'project',
+        type: 'project',
         target: 'proj-1',
         creating_user_id: 'user-42',
         created_at: null,

--- a/web/resources/js/exchange/useExport.js
+++ b/web/resources/js/exchange/useExport.js
@@ -2,10 +2,11 @@ import { createCSVBuilder } from '../utils/files/createCSVBuilder.js';
 import { saveTextFile } from '../utils/files/saveTextFile.js';
 import { usePage } from '@inertiajs/vue3';
 import { toLocaleDateString } from '../utils/date/toLocaleDateString.js';
+import { buildNotesCSV } from './buildNotesCSV.js';
 
 /**
  * Export hook for exporting project data.
- * @return {{exportToCSV: (function({contents: *, users: *}): Promise<void>)}}
+ * @return {{exportToCSV: (function({contents: *, users: *}): Promise<void>), exportNotesToCSV: (function({notes: *, codes: *, sources: *, users: *}): Promise<void>)}}
  */
 export const useExport = () => {
   const { project } = usePage().props;
@@ -13,7 +14,16 @@ export const useExport = () => {
   return {
     exportToCSV: ({ contents, users }) =>
       exportToCSV({ contents, project, users }),
+    exportNotesToCSV: ({ notes, codes, sources, users }) =>
+      exportNotesToCSV({ notes, codes, sources, project, users }),
   };
+};
+
+const exportNotesToCSV = ({ notes, codes, sources, project, users }) => {
+  const out = buildNotesCSV({ notes, codes, sources, project, users });
+  const date = new Date().toLocaleDateString().replace(/[_.:,\s]+/g, ' ');
+  const name = `OpenQDA ${project.name} Notes ${date}.csv`;
+  return saveTextFile({ text: out, name, type: 'text/csv' });
 };
 
 const exportToCSV = ({ contents, project, users }) => {


### PR DESCRIPTION
This PR addresses the "notes" item from issue #336, which tracks the need to export analytic artifacts for documentation purposes.

## What this adds

A new "Export Notes" button in the Analysis page's Export tab. Clicking it downloads a CSV file containing all project notes, including:
- the note content
- what each note is attached to (code, source, or project)
- the name of that entity (e.g. "Drinking" instead of a raw ID)
- who wrote the note
- the timestamp
- whether it was private or visible to the team

## Changes

- `exchange/buildNotesCSV.js` — new pure function that builds the CSV, resolving code and source names from their IDs
- `exchange/buildNotesCSV.test.js` — tests covering name resolution, visibility labels, and user lookup
- `exchange/useExport.js` — wired in the new export function
- `Pages/AnalysisPage.vue` — added the Export Notes button in the Export tab

Partially closes #336 (addresses the notes checkbox)