### PR TITLE
feature: reactive autoforms for different variables types

### DIFF
--- a/web/app/Http/Controllers/CodingController.php
+++ b/web/app/Http/Controllers/CodingController.php
@@ -11,6 +11,7 @@ use App\Models\Codebook;
 use App\Models\Note;
 use App\Models\Project;
 use App\Models\Source;
+use App\Models\Variable;
 use App\Traits\BuildsNestedCode;
 use App\Traits\SourceExists;
 use App\Traits\ValidatesStoragePath;
@@ -165,6 +166,7 @@ class CodingController extends Controller
             'codebooks' => $codebooks,
             'allCodes' => $allCodes,
             'projectId' => $projectId,
+            'variables' => Variable::where('project_id', $projectId)->get(),
             'notes' => $notes,
         ]);
     }

--- a/web/resources/js/Pages/CodingPage.vue
+++ b/web/resources/js/Pages/CodingPage.vue
@@ -106,11 +106,19 @@
             </Transition>
             <Button
               v-if="props.source && !sorting"
-              @click="showSourceNotes = true"
+              @click="showOverlay('notes', true)"
               :title="`Manage notes for source '${props.source?.name}'`"
               variant="outline"
             >
               <ChatBubbleLeftEllipsisIcon class="w-4 h-4" />
+            </Button>
+            <Button
+              v-if="props.source"
+              @click="showOverlay('variables', true)"
+              :title="`Manage Variables for source '${props.source.name}'`"
+              variant="outline"
+            >
+              <VariableIcon class="w-4 h-4" />
             </Button>
             <CreateDialog
               v-if="!sorting"
@@ -139,11 +147,11 @@
         </CodingEditor>
         <SideOverlay
           v-if="props.source"
-          title="Manage Notes"
-          :show="showSourceNotes"
-          @close="showSourceNotes = false"
+          :title="overlayOptions[optionsType]?.label"
+          :show="showOptions"
+          @close="showOptions = false"
         >
-          <div class="p-2">
+          <div class="p-2" v-if="optionsType === 'notes'">
             <Headline3 class="mb-2 p-2"
               >Notes linked to {{ props.source.name }}</Headline3
             >
@@ -152,6 +160,12 @@
               :target="props.source"
               type="source"
             />
+          </div>
+          <div class="p-2" v-if="optionsType === 'variables'">
+            <Headline3 class="mb-2 p-2">
+              Variables linked to {{ props.source.name }}
+            </Headline3>
+            <VariablesList :source="props.source" />
           </div>
         </SideOverlay>
       </div>
@@ -178,7 +192,10 @@
 
 <script setup>
 import { PlusIcon } from '@heroicons/vue/24/solid';
-import { ChatBubbleLeftEllipsisIcon } from '@heroicons/vue/24/outline';
+import {
+  ChatBubbleLeftEllipsisIcon,
+  VariableIcon,
+} from '@heroicons/vue/24/outline';
 import {
   computed,
   onMounted,
@@ -221,6 +238,8 @@ import SideOverlay from '../Components/layout/SideOverlay.vue';
 import NoteList from './coding/tree/NoteList.vue';
 import Headline3 from '../Components/layout/Headline3.vue';
 import { useCodeTree } from './coding/tree/useCodeTree.js';
+import VariablesList from '../domain/variables/VariablesList.vue';
+import { useVariables } from '../domain/variables/useVariables.js';
 
 const props = defineProps(['source', 'sources', 'allCodes', 'projectId']);
 
@@ -338,11 +357,12 @@ const createCodeHandler = async (formData) => {
 
 const { sorting, setSorting } = useCodeTree();
 
-//------------------------------------------------------------------------
-// NOTES
-//------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+// NOTES AND VARIABLES
+/*---------------------------------------------------------------------------*/
 const { initNotes, notes: storedNotes } = useNotes();
-const showSourceNotes = ref(false);
+const { initVariables } = useVariables();
+
 const notesForSource = computed(() => {
   if (!storedNotes?.value?.length || !props.source?.id) {
     return [];
@@ -351,6 +371,21 @@ const notesForSource = computed(() => {
     (note) => note.type === 'source' && note.target === props.source.id
   );
 });
+
+const overlayOptions = {
+  variables: {
+    label: 'Manage Source Variables',
+  },
+  notes: {
+    label: 'Manage Source Notes',
+  },
+};
+const showOptions = ref(false);
+const optionsType = ref('');
+const showOverlay = (type, value) => {
+  optionsType.value = type;
+  showOptions.value = value;
+};
 
 //------------------------------------------------------------------------
 // CLEANUP
@@ -385,6 +420,7 @@ onMounted(async () => {
   codingInitialized.value = true;
 
   initNotes();
+  initVariables();
 });
 
 onBeforeUnmount(() => {

--- a/web/resources/js/domain/variables/VariablesList.vue
+++ b/web/resources/js/domain/variables/VariablesList.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
-import { PencilIcon, PlusIcon, TrashIcon } from '@heroicons/vue/20/solid';
+import {
+  InformationCircleIcon,
+  PencilIcon,
+  PlusIcon,
+  TrashIcon,
+} from '@heroicons/vue/20/solid';
 import Button from '../../Components/interactive/Button.vue';
 import { computed, ref } from 'vue';
 import AutoForm from '../../form/AutoForm.vue';
@@ -71,7 +76,28 @@ const forms = {
         value: {
           type: String,
           autofocus: !!doc.name,
-          defaultValue,
+          defaultValue: (formData) => {
+            if (!formData) return defaultValue ?? undefined;
+            return formData.get('value') ?? undefined;
+          },
+          formType: (formData) => {
+            if (!formData) return 'text';
+            const type = formData.get('type');
+            switch (type) {
+              case 'date':
+                return 'date';
+              case 'datetime':
+                return 'datetime-local';
+              case 'boolean':
+                return 'checkbox';
+              case 'integer':
+              case 'float':
+                return 'number';
+              case 'text':
+              default:
+                return 'text';
+            }
+          },
         },
       };
     },
@@ -234,6 +260,7 @@ const submitForm = async (data) => {
         @submit="submitForm"
         :show-cancel="false"
         :show-submit="false"
+        :reactive="true"
       />
       <div class="flex justify-between items-center">
         <Button variant="outline" @click.stop="setForm(null)"> Cancel </Button>
@@ -245,6 +272,17 @@ const submitForm = async (data) => {
           {{ form.submit.label }}
         </Button>
       </div>
+    </div>
+    <div class="mt-5 border rounded border-input">
+      <div class="flex gap-1 items-center p-2">
+        <InformationCircleIcon class="w-4 h-4 text-secondary" />
+        <span>Please note</span>
+      </div>
+      <p class="text-sm text-foreground/80 p-2">
+        Once you created a new Variable, its "name", "type", and "description"
+        are fixed and you can only change their "value". We will support
+        cross-Source Variable editing in a future release.
+      </p>
     </div>
   </div>
 </template>

--- a/web/resources/js/form/AutoForm.vue
+++ b/web/resources/js/form/AutoForm.vue
@@ -3,12 +3,14 @@
  | AutoForm is a lightweight HoC that constructs forms
  | by given schema.
  *--------------------------------------------------*/
-import { onMounted, ref } from 'vue';
+import { computed, ref, useTemplateRef } from 'vue';
 import { cn } from '../utils/css/cn.js';
 import { transformSchema } from './transformSchema.js';
 import { initForms } from './initForms.js';
 import InputError from '../../../vendor/laravel/jetstream/stubs/inertia/resources/js/Components/InputError.vue';
 import Button from '../Components/interactive/Button.vue';
+import { debounce } from '../utils/dom/debounce.js';
+import { noop } from '../utils/function/noop.js';
 
 // make sure we have registered all elements
 initForms();
@@ -36,21 +38,33 @@ const props = defineProps({
     type: String,
     default: 'default',
   },
+  reactive: {
+    type: Boolean,
+    default: false,
+  },
 });
 const emit = defineEmits(['cancel', 'submit']);
-const fields = ref(null);
-const validationErrors = ref({});
-const submitFailed = ref(false);
-
-onMounted(() => {
-  fields.value = Object.entries(props.schema).map(([key, value]) => {
-    return transformSchema(value, key);
+const fields = computed(() => {
+  if (!props.schema) return null;
+  return Object.entries(props.schema).map(([key, value]) => {
+    return transformSchema(value, key, formData.value);
   });
 });
+const validationErrors = ref({});
+const submitFailed = ref(false);
+const submitting = ref(false);
 
-const validateForm = (e) => {
+const submitForm = (e) => {
   e.preventDefault();
   e.stopPropagation();
+  submitting.value = true;
+  try {
+    validateForm(e);
+  } finally {
+    submitting.value = false;
+  }
+};
+const validateForm = (e) => {
   const formData = new FormData(e.target);
   const data = [...formData.entries()];
   const validation = {};
@@ -76,13 +90,25 @@ const validateForm = (e) => {
   const toSubmit = Object.fromEntries(data);
   emit('submit', toSubmit);
 };
+
+const formRef = useTemplateRef('form-ref');
+const formData = ref(null);
+const onFormInput = props.reactive
+  ? debounce(() => {
+      if (!formRef?.value || submitting.value) return;
+      formData.value = new FormData(formRef.value);
+    }, 500)
+  : noop;
 </script>
 
 <template>
   <form
     :id="props.id"
     :class="cn('bg-transparent', $props.class)"
-    @submit="validateForm"
+    ref="form-ref"
+    @submit="submitForm"
+    @input="onFormInput"
+    @change="onFormInput"
   >
     <component
       v-for="({ component, data }, index) in fields"
@@ -90,8 +116,8 @@ const validateForm = (e) => {
       :is="component"
       v-bind="data"
       :size="props.size"
-      :disabled="!!data.disabled"
-      :value="data.defaultValue"
+      :disabled="submitting || !!data.disabled"
+      :value="data.value ?? data.defaultValue"
       :required="data.required"
       :validation="validationErrors[data.name]"
     ></component>
@@ -104,10 +130,18 @@ const validateForm = (e) => {
       v-if="showSubmit !== false || showCancel !== false"
       class="flex items-center justify-between mt-2"
     >
-      <Button variant="outline" :size="props.size" @click="$emit('cancel')"
+      <Button
+        variant="outline"
+        :size="props.size"
+        @click.stop="$emit('cancel')"
+        :disabled="submitting"
         >Cancel</Button
       >
-      <Button type="submit" :size="props.size" class="float-right"
+      <Button
+        type="submit"
+        :size="props.size"
+        class="float-right"
+        :disabled="submitting"
         >Submit</Button
       >
     </div>

--- a/web/resources/js/form/TextArea.vue
+++ b/web/resources/js/form/TextArea.vue
@@ -77,6 +77,7 @@ const resolveText = variantAuthority(textStyle);
         props.validation?.valid === false && 'border-destructive'
       )
     "
+    v-bind="$attrs"
     v-model="value"
   ></textarea>
   <InputError v-for="error in errors" :key="error" :message="error" />

--- a/web/resources/js/form/transformSchema.js
+++ b/web/resources/js/form/transformSchema.js
@@ -1,6 +1,6 @@
 import { FormElements } from './FormElements.js';
 import { markRaw } from 'vue';
-import { isDefined } from '@vueuse/core';
+import { isDefined } from '../utils/isDefined.js';
 
 /**
  * Transforms a given schema into a normalized
@@ -8,39 +8,60 @@ import { isDefined } from '@vueuse/core';
  * by the AutoForm component and it's children
  * @param value {FormSchema}
  * @param name {string}
+ * @param formData {object=} optional, formData used in reactive form to adjust schema, based on input values
  * @return {{component: Raw<unknown>, data: {optional: boolean, type}}}
  */
-export const transformSchema = (value, name) => {
+export const transformSchema = (value, name, formData) => {
   let schema = { ...value };
   if (typeof value === 'function') {
     schema = { type: value, optional: false };
   }
   schema.name = name;
 
-  // every field is optional by default unless
+  // every field is required by default unless
   // explicitly made optional by intent
+  if (Object.hasOwn(schema, 'required') && Object.hasOwn(schema, 'optional')) {
+    throw new Error(
+      `Schema may contain either required or optional but never both`
+    );
+  }
+
   let required = true;
-  if (schema.optional === true || schema.required === false) {
+  const optionalValue = getValueOrFn(schema.optional, formData);
+  const requiredValue = getValueOrFn(schema.required, formData);
+  if (optionalValue === true || requiredValue === false) {
     required = false;
   }
 
+  // resolve to the final "required" html property
+  // to enable browser support in required fields
   schema.required = required;
-
   delete schema.optional;
-  schema.formType = getFormType(schema);
+
+  // reactive support for certain simple properties
+  const values = ['readonly', 'disabled', 'defaultValue'];
+  for (const propName of values) {
+    if (Object.hasOwn(schema, propName)) {
+      schema[propName] = getValueOrFn(schema[propName], formData);
+    }
+  }
+
+  schema.formType = getFormType(schema, formData);
   schema.formElement =
     FormElements.get(schema.formType) ?? FormElements.default();
-  schema.label = getLabel(schema);
-  schema.options = getOptions(schema);
-  schema.validate = getValidator(schema);
+  schema.label = getLabel(schema, formData);
+  schema.options = getOptions(schema, formData);
+  schema.validate = getValidator(schema, formData);
+
   const data = ((_schema) => {
     const { type, formType, formElement, data, ...rest } = _schema;
-    return { type: formType, ...rest };
+    const value = formData ? formData.get(name) : undefined;
+    return { type: formType, value, ...rest };
   })(schema);
 
   return {
     data,
-    component: markRaw(schema.formElement),
+    component: schema.formElement && markRaw(schema.formElement),
   };
 };
 
@@ -50,8 +71,20 @@ export const transformSchema = (value, name) => {
 // the following functions are only exported for tests
 // =====================================================
 
-export const getFormType = ({ formType, type, options, allowedValues }) => {
-  if (formType) return formType;
+export const getValueOrFn = (value, formData) => {
+  if (typeof value === 'function') {
+    return value(formData);
+  }
+  return value;
+};
+
+export const getFormType = (
+  { formType, type, options, allowedValues },
+  formData
+) => {
+  const formTypeT = typeof formType;
+  if (formTypeT === 'function') return formType(formData);
+  if (formTypeT === 'string') return formType;
 
   if (options || allowedValues) {
     return 'select';
@@ -71,14 +104,19 @@ export const getFormType = ({ formType, type, options, allowedValues }) => {
   }
 };
 
-export const getLabel = ({ label, name }) => {
-  if (label || label === null) return label;
+export const getLabel = ({ label, name }, formData) => {
+  const typeL = typeof label;
+  if (typeL === 'function') return label(formData);
+  if (label === null || typeL === 'string') return label;
+
   return (
     name
-      // remove whitespace
+      // remove loading whitespace
       .trim()
-      // split at any uppercase
-      .split(/[A-Z]/g)
+      // split at any single uppercase
+      .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+      .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+      .split(/\s+/)
       // capitalize
       .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
       // construct label
@@ -86,8 +124,9 @@ export const getLabel = ({ label, name }) => {
   );
 };
 
-export const getOptions = ({ formType, options, allowedValues }) => {
-  if (options) return options;
+export const getOptions = ({ formType, options, allowedValues }, formData) => {
+  const opts = getValueOrFn(options, formData);
+  if (opts) return opts;
   if (allowedValues) {
     return;
   }
@@ -106,22 +145,22 @@ export const getOptions = ({ formType, options, allowedValues }) => {
   }
 };
 
-export const getValidator = (schema) => {
+export const getValidator = (field) => {
   return (key, value) => {
     const validation = { key, value, valid: true, errors: [] };
     const addError = ({ message }) => {
       validation.valid = false;
       validation.errors.push(message);
     };
-    if (!schema) {
+    if (!field) {
       addError({ message: `${key} is not defined in schema` });
       return validation;
     }
 
-    const { label } = schema;
+    const { label } = field;
     const name = label || key;
 
-    if (schema.required && !requiredValueDefined(value)) {
+    if (field.required && !requiredValueDefined(value)) {
       addError({ message: `${name} is required` });
     }
 

--- a/web/resources/js/form/transformSchema.test.js
+++ b/web/resources/js/form/transformSchema.test.js
@@ -1,0 +1,216 @@
+import { describe, expect, vi } from 'vitest';
+import {
+  getLabel,
+  getOptions,
+  transformSchema,
+  getFormType,
+  getValidator,
+} from './transformSchema.js';
+
+describe('transform schema', () => {
+  describe(getLabel.name, () => {
+    it('returns a given label', () => {
+      const label = 'moo';
+      expect(getLabel({ label })).toEqual('moo');
+    });
+    it('derives from function', () => {
+      const ctx = { moo: 1 };
+      const label = vi.fn((formData) => {
+        expect(formData).toBe(ctx);
+        return 'foo';
+      });
+      expect(getLabel({ label }, ctx)).toEqual('foo');
+      expect(label).toHaveBeenCalled();
+    });
+    it('suppresses label with null', () => {
+      const label = null;
+      expect(getLabel({ label })).toEqual(null);
+    });
+    it('creates a humanized fallback from field name', () => {
+      const names = [
+        ['foo', 'Foo'],
+        ['barBaz', 'Bar Baz'],
+        [' foo ', 'Foo'],
+        [' barBaz ', 'Bar Baz'],
+        [' barXMLParser ', 'Bar XML Parser'],
+      ];
+      for (const [name, expected] of names) {
+        expect(getLabel({ name })).toEqual(expected);
+      }
+    });
+  });
+  describe(getOptions.name, () => {
+    it('skips if allowed values are defined', () => {
+      const allowedValues = [{ foo: 1 }, { bar: 1 }];
+      expect(getOptions({ allowedValues })).toEqual(undefined);
+    });
+    it('resolved a function to options', () => {
+      const expected = [{ foo: 1 }, { bar: 1 }];
+      const ctx = { moo: 1 };
+      const options = vi.fn((formData) => {
+        expect(formData).toBe(ctx);
+        return expected;
+      });
+      expect(getOptions({ options }, ctx)).toStrictEqual(expected);
+      expect(options).toHaveBeenCalled();
+    });
+    it('returns options if already given', () => {
+      const options = [{ foo: 1 }, { bar: 1 }];
+      expect(getOptions({ options })).toStrictEqual(options);
+    });
+    it('resolves from formType', () => {
+      const types = [
+        [
+          'select-radio',
+          [
+            {
+              value: true,
+              label: 'Yes',
+            },
+            {
+              value: false,
+              label: 'No',
+            },
+          ],
+        ],
+      ];
+      for (const [formType, expected] of types) {
+        expect(getOptions({ formType })).toStrictEqual(expected);
+      }
+    });
+  });
+  describe(getFormType.name, () => {
+    it('throws on unknown type', () => {
+      const schema = { type: 'test' };
+      expect(() => getFormType(schema)).toThrow(`unknown type test`);
+    });
+    it('passes on formType', () => {
+      const schema = { formType: 'test' };
+      expect(getFormType(schema)).toEqual('test');
+    });
+    it('creates a select from options', () => {
+      const schemas = [{ options: [] }, { allowedValues: [] }];
+      for (const schema of schemas) {
+        expect(getFormType(schema)).toEqual('select');
+      }
+    });
+    it('creates a type from constructor', () => {
+      const values = [
+        [String, 'text'],
+        [Number, 'number'],
+        [Boolean, 'checkbox'],
+      ];
+      for (const [type, expected] of values) {
+        expect(getFormType({ type })).toBe(expected);
+      }
+    });
+    it('resolves a function formType', () => {
+      const ctx = { moo: 1 };
+      const formType = vi.fn((formData) => {
+        expect(formData).toBe(ctx);
+        return 'moo';
+      });
+      const schema = { formType };
+      expect(getFormType(schema, ctx)).toEqual('moo');
+      expect(formType).toHaveBeenCalled();
+    });
+  });
+  describe(getValidator.name, () => {
+    const evaluate = (result, expected) => {
+      const { key, value, valid, errors } = result;
+      expect(key).toEqual(expected.key);
+      expect(value).toEqual(expected.value);
+      expect(errors).toStrictEqual(expected.errors);
+      expect(valid).toEqual(expected.valid);
+    };
+    it('fails if key is not in schema', () => {
+      const validate = getValidator();
+      evaluate(validate('moo'), {
+        key: 'moo',
+        value: undefined,
+        valid: false,
+        errors: ['moo is not defined in schema'],
+      });
+    });
+    it('fails if key is required but required value is not defined', () => {
+      const schema = {
+        type: String,
+        label: 'Moo',
+        required: true,
+      };
+      const validate = getValidator(schema);
+      evaluate(validate('moo'), {
+        key: 'moo',
+        value: undefined,
+        valid: false,
+        errors: ['Moo is required'],
+      });
+    });
+  });
+  describe(transformSchema.name, () => {
+    it('transforms a most minimal schema to a normalized version', () => {
+      const schema = { type: String };
+      const normalized = transformSchema(schema, 'foo');
+      expect(normalized.component).toBe(undefined);
+
+      const { validate, ...data } = normalized.data;
+      expect(data).toStrictEqual({
+        label: 'Foo',
+        name: 'foo',
+        required: true,
+        options: undefined,
+        type: 'text',
+        value: undefined,
+      });
+    });
+    it('transforms with allowed values', () => {
+      const schema = { type: String, allowedValues: ['moo', 'foo'] };
+      const normalized = transformSchema(schema, 'foo');
+      expect(normalized.component).toBe(undefined);
+
+      const { validate, ...data } = normalized.data;
+      expect(data).toStrictEqual({
+        label: 'Foo',
+        name: 'foo',
+        required: true,
+        options: undefined,
+        allowedValues: ['moo', 'foo'],
+        type: 'select',
+        value: undefined,
+      });
+    });
+    it('transforms with resolver functions', () => {
+      const data = {
+        optional: true,
+        formType: 'foobar',
+        label: 'Foo XML Parser',
+        disabled: true,
+        options: [{ moo: 1 }, { foo: 2 }],
+      };
+      const schema = {
+        type: String,
+        optional: () => data.optional,
+        formType: () => data.formType,
+        label: () => data.label,
+        disabled: () => data.disabled,
+        options: () => data.options,
+      };
+
+      const formData = new FormData();
+      formData.set('foo', 'moo');
+      const normalized = transformSchema(schema, 'foo', formData);
+      expect(normalized.component).toBe(undefined);
+
+      const { validate, ...field } = normalized.data;
+      expect(field).toStrictEqual({
+        label: 'Foo XML Parser',
+        name: 'foo',
+        required: false,
+        options: [{ moo: 1 }, { foo: 2 }],
+        type: 'foobar',
+        disabled: true,
+        value: 'moo',
+      });
+    });
+  });
+});

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -32,13 +32,14 @@ export default defineConfig({
     server: {
         watch: {
             ignored: [
-                '**/node_modules/**',
-                '**/dist/**',
                 '**/.laravel/**',
                 '**/.deploy/**',
                 '**/.phpunit.cache/**',
                 '**/.idea',
                 '**/.deploy',
+                '**/.git/**',
+                '**/dist/**',
+                '**/node_modules/**',
                 '**/app/**',
                 '**/vendor/**',
                 '**/bootstrap/**',
@@ -50,27 +51,33 @@ export default defineConfig({
                 '**/storage/**',
                 '**/scripts/**',
                 '**/stories/**',
-                '**/node_modules/**',
-                '**/.git/**',
             ]
         }
     },
     test: {
         include: ['resources/js/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
         exclude: [
-            '**/node_modules/**',
-            'public/',
-            '**/dist/**',
             '**/cypress/**',
             '**/.{idea,git,cache,output,temp}/**',
-            'stories',
-            '.storybook',
-            'app/',
-            'bootstrap/',
-            'config/',
-            'database/',
-            'routes/',
-            '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*'],
+            '**/stories/**',
+            '**/.storybook/**',
+            '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*',
+            '**/dist/**',
+            '**/node_modules/**',
+            '**/app/**',
+            '**/bootstrap/**',
+            '**/config/**',
+            '**/coverage/**',
+            '**/data/**',
+            '**/database/**',
+            '**/docker/**',
+            '**/routes/**',
+            '**/storage/**',
+            '**/scripts/**',
+            '**/stories/**',
+            '**/vendor/**',
+        ],
+
         // enable jest-like global test APIs
         globals: true,
         // simulate DOM with happy-dom


### PR DESCRIPTION
This adds form reactivity in order to change field types and properties, based on other fields value of a the same form.
This is currently primarily used in the variables form, because the variable value requires a different input types depending on the selected type option (date, text, boolean, number etc.)


Example:
<img width="446" height="375" alt="image" src="https://github.com/user-attachments/assets/f9be306e-e17b-4be0-ba78-82f050e5724b" />

switching type from text to date:
<img width="450" height="379" alt="image" src="https://github.com/user-attachments/assets/3a3c2867-c5e0-48cc-8c9a-d33ac5c3995c" />
